### PR TITLE
Reimplement memory map algorithm with functional decomposition

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,7 @@ jobs:
       - name: Lint with pylint
         run:
           make test-lint
+      - name: Unit Tests
+        run:
+          make test-unit
 

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,21 @@ venv/.stamp: venv/bin/activate requirements.txt
 venv/bin/activate:
 	python3 -m venv venv
 
-.PHONY: lint
+.PHONY: test-lint
 test-lint: virtualenv
 	. venv/bin/activate && pylint *.py
 
 .PHONY: test
 test: test-lint
+
+UNIT_TESTS = tests/test-memory-map.py
+
+.PHONY: test-unit
+test-unit: virtualenv
+	. venv/bin/activate && python -m unittest $(UNIT_TESTS)
+
+.PHONY: test
+test: test-unit
 
 clean:
 	-rm -rf venv __pycache__

--- a/generate_ldscript.py
+++ b/generate_ldscript.py
@@ -10,15 +10,13 @@ import sys
 import jinja2
 import pydevicetree
 
+from memory_map import get_memories, get_load_map
+
 TEMPLATES_PATH = "templates"
 
 # Sets the threshold size of the ITIM at or above which the "ramrodata" layout
 # places the text section into the ITIM
 MAGIC_RAMRODATA_TEXT_THRESHOLD = 0x8000
-
-ROM_MEMORY_NAME = "rom"
-RAM_MEMORY_NAME = "ram"
-ITIM_MEMORY_NAME = "itim"
 
 def missingvalue(message):
     """
@@ -28,149 +26,6 @@ def missingvalue(message):
     fail.
     """
     raise jinja2.UndefinedError(message)
-
-class Region:
-    """Describes a memory region requested by the Devicetree"""
-    # pylint: disable=too-few-public-methods
-    def __init__(self, node, base, size, name):
-        self.node = node
-        self.base = base
-        self.size = size
-        self.name = name
-
-    def template_value(self, attributes):
-        """Format as a dict for templating"""
-        return {
-            "name": self.name,
-            "attributes": attributes,
-            "base": "0x%x" % self.base,
-            "size": "0x%x" % self.size,
-        }
-
-    def __eq__(self, other):
-        return self.base == other.base and self.size == other.size
-
-    def __hash__(self):
-        return (self.base, self.size).__hash__()
-
-def get_chosen_region(dts, chosen_property_name, name):
-    """Extract the requested address region from the chosen property"""
-    chosen_property = dts.chosen(chosen_property_name)
-
-    if chosen_property:
-        chosen_node = dts.get_by_reference(chosen_property[0])
-        chosen_range = chosen_property[1]
-        chosen_offset = chosen_property[2]
-
-        reg = chosen_node.get_reg()[chosen_range]
-
-        base = reg[0] + chosen_offset
-        size = reg[1] - chosen_offset
-
-        return Region(chosen_node, base, size, name)
-    return None
-
-def get_ram(dts):
-    """Get the RAM from the devicetree, if one is chosen"""
-    region = get_chosen_region(dts, "metal,ram", RAM_MEMORY_NAME)
-    if region is not None:
-        path = region.node.get_path()
-        top = region.base + region.size - 1
-        print("\tRAM:  0x%08x-0x%08x (%s)" % (region.base, top, path))
-    return region
-
-def get_itim(dts):
-    """Get the ITIM from the devicetree, if one is chosen"""
-    region = get_chosen_region(dts, "metal,itim", ITIM_MEMORY_NAME)
-    if region is not None:
-        path = region.node.get_path()
-        top = region.base + region.size - 1
-        print("\tITIM: 0x%08x-0x%08x (%s)" % (region.base, top, path))
-    return region
-
-def get_itim_size(dts):
-    """Get the size of the ITIM from the Devicetree"""
-    region = get_chosen_region(dts, "metal,itim", ITIM_MEMORY_NAME)
-    if region is not None:
-        return region.size
-    return 0
-
-def get_rom(dts):
-    """Get the ROM from the devicetree, if one is chosen"""
-    region = get_chosen_region(dts, "metal,entry", ROM_MEMORY_NAME)
-    if region is not None:
-        path = region.node.get_path()
-        top = region.base + region.size - 1
-        print("\tROM:  0x%08x-0x%08x (%s)" % (region.base, top, path))
-    return region
-
-def drop_identical_regions(regions):
-    """Removes Regions pointing at identical regions of memory"""
-    return list(set(regions))
-
-def get_memories(dts):
-    """
-    Extract the memory regions and turn them into the mapping to implement
-    in the linker script
-    """
-    # pylint: disable=too-many-branches
-    regions = [x for x in [get_ram(dts), get_itim(dts), get_rom(dts)] if x is not None]
-    regions = drop_identical_regions(regions)
-
-    if len(regions) == 0:
-        print("No memory regions are available")
-        sys.exit(1)
-    elif len(regions) == 1:
-        region = regions[0]
-        if region.name != RAM_MEMORY_NAME:
-            # If we only have one region, it has to be RAM
-            region.name = RAM_MEMORY_NAME
-        ram, rom, itim = [{
-            "vma": region.name,
-            "lma": region.name
-        }] * 3
-        return [region.template_value("rwxai")], ram, rom, itim
-    elif len(regions) == 2:
-        memories = []
-        for region in regions:
-            if region.name == ROM_MEMORY_NAME:
-                memories.append(region.template_value("rxi!wa"))
-                rom = {
-                    "lma": region.name,
-                    "vma": region.name
-                }
-            elif region.name == RAM_MEMORY_NAME:
-                memories.append(region.template_value("rwai!x"))
-                ram, itim = [{
-                    "lma": ROM_MEMORY_NAME,
-                    "vma": region.name
-                }] * 2
-            else:
-                print("RAM or ROM missing")
-                sys.exit(1)
-        return memories, ram, rom, itim
-    else:
-        memories = []
-        for region in regions:
-            if region.name == ROM_MEMORY_NAME:
-                memories.append(region.template_value("rxi!wa"))
-                rom = {
-                    "lma": region.name,
-                    "vma": region.name
-                }
-            elif region.name == RAM_MEMORY_NAME:
-                memories.append(region.template_value("rwai!x"))
-                ram = {
-                    "lma": ROM_MEMORY_NAME,
-                    "vma": region.name
-                }
-            elif region.name == ITIM_MEMORY_NAME:
-                memories.append(region.template_value("rwxai"))
-                itim = {
-                    "lma": ROM_MEMORY_NAME,
-                    "vma": region.name
-                }
-        return memories, ram, rom, itim
 
 def parse_arguments(argv):
     """Parse the arguments into a dictionary with argparse"""
@@ -210,6 +65,19 @@ def get_template(parsed_args):
 
     return template
 
+def print_memories(memories):
+    """Report chosen memories to stdout"""
+    print("Using layout:")
+    for _, memory in memories.items():
+        end = memory["base"] + memory["length"] - 1
+        print("\t%4s: 0x%08x-0x%08x (%s)" % (memory["name"], memory["base"], end, memory["path"]))
+
+def get_itim_length(memories):
+    """Get the length of the itim, if it exists"""
+    if "itim" in memories and "length" in memories["itim"]:
+        return memories["itim"]["length"]
+    return 0
+
 def main(argv):
     """Parse arguments, extract data, and render the linker script to file"""
     parsed_args = parse_arguments(argv)
@@ -218,17 +86,19 @@ def main(argv):
 
     dts = pydevicetree.Devicetree.parseFile(parsed_args.dts, followIncludes=True)
 
-    print("Selected memories in design:")
-    memories, ram, rom, itim = get_memories(dts)
+    memories = get_memories(dts)
+    print_memories(memories)
+
+    ram, rom, itim = get_load_map(memories)
 
     if parsed_args.scratchpad:
         # Put all rom contents in ram
-        ram["lma"] = RAM_MEMORY_NAME
-        itim["lma"] = RAM_MEMORY_NAME
+        ram["lma"] = "ram"
+        itim["lma"] = "ram"
         rom = ram
 
     text_in_itim = False
-    if parsed_args.ramrodata and get_itim_size(dts) >= MAGIC_RAMRODATA_TEXT_THRESHOLD:
+    if parsed_args.ramrodata and get_itim_length(memories) >= MAGIC_RAMRODATA_TEXT_THRESHOLD:
         text_in_itim = True
         print(".text section included in ITIM")
     elif parsed_args.ramrodata:
@@ -244,7 +114,7 @@ def main(argv):
         boot_hart = 0
 
     values = {
-        "memories" : memories,
+        "memories" : list(memories.values()),
         "default_stack_size" : "0x400",
         "default_heap_size" : "0x800",
         "num_harts" : len(harts),

--- a/generate_ldscript.py
+++ b/generate_ldscript.py
@@ -246,7 +246,7 @@ def main(argv):
     values = {
         "memories" : memories,
         "default_stack_size" : "0x400",
-        "default_heap_size" : "0x400",
+        "default_heap_size" : "0x800",
         "num_harts" : len(harts),
         "boot_hart" : boot_hart,
         "chicken_bit" : 1,

--- a/memory_map.py
+++ b/memory_map.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 SiFive Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functions for converting Devicetrees to the template parameterization"""
+
+import sys
+
+
+def get_memories(tree):
+    """Given a Devicetree, get the list of memories to describe in the
+       linker script"""
+    regions = get_chosen_regions(tree)
+    compute_address_ranges(regions)
+    memories = invert_regions_to_memories(regions)
+    compute_attributes(memories)
+    format_hex(memories)
+
+    return memories
+
+
+def get_load_map(memories):
+    """Given the list of memories in the linker script, get the lma/vma
+       pairs for each of the regions in the linker script"""
+    ram = dict()
+    rom = dict()
+    itim = dict()
+
+    if "testram" in memories:
+        rom["lma"] = "testram"
+        rom["vma"] = "testram"
+        ram["lma"] = "testram"
+        ram["vma"] = "testram"
+        itim["lma"] = "testram"
+
+        if "itim" in memories["testram"]["contents"]:
+            itim["vma"] = "testram"
+        elif "itim" in memories:
+            itim["vma"] = "itim"
+        else:
+            itim["vma"] = "testram"
+    else:
+        rom["lma"] = "rom"
+        rom["vma"] = "rom"
+        ram["lma"] = "rom"
+        ram["vma"] = "ram"
+        itim["lma"] = "rom"
+
+        if "itim" in memories["rom"]["contents"]:
+            itim["vma"] = "rom"
+        elif "itim" in memories["ram"]["contents"]:
+            itim["vma"] = "ram"
+        elif "itim" in memories:
+            itim["vma"] = "itim"
+        else:
+            itim["vma"] = "rom"
+
+    return ram, rom, itim
+
+
+def get_chosen_region(dts, chosen_property_name):
+    """Extract the requested address region from the chosen property"""
+    chosen_property = dts.chosen(chosen_property_name)
+
+    if chosen_property:
+        chosen_node = dts.get_by_reference(chosen_property[0])
+        chosen_region = chosen_property[1]
+        chosen_offset = chosen_property[2]
+
+        return {
+            "node": chosen_node,
+            "region": chosen_region,
+            "offset": chosen_offset,
+        }
+    return None
+
+
+def get_chosen_regions(tree):
+    """Given the tree, get the regions requested by chosen properties.
+       Exits with an error if required properties are missing or the
+       parameters are invalid"""
+    regions = {
+        "entry": get_chosen_region(tree, "metal,entry"),
+        "ram": get_chosen_region(tree, "metal,ram"),
+        "itim": get_chosen_region(tree, "metal,itim"),
+    }
+    if regions["entry"] is None:
+        print("ERROR: metal,entry is not defined by the Devicetree")
+        sys.exit(1)
+    if regions["ram"] is None:
+        print("ERROR: metal,ram is not defined by the Devicetree")
+        sys.exit(1)
+    return regions
+
+
+def compute_address_range(region):
+    """Extract the address range from the reg of the Node"""
+    reg = region["node"].get_reg()
+    base = reg[region["region"]][0] + region["offset"]
+    length = reg[region["region"]][1] - region["offset"]
+
+    region["base"] = base
+    region["length"] = length
+
+
+def compute_address_ranges(regions):
+    """Given the requested regions, compute the effective address ranges
+       to use for each"""
+    for _, region in regions.items():
+        if region is not None:
+            compute_address_range(region)
+
+    # partition regions by node
+    region_values = [r for r in regions.values() if r is not None]
+    nodes = list({region["node"] for region in region_values})
+    for node in nodes:
+        partition = [
+            region for region in region_values if region["node"] == node]
+
+        # sort regions by offset
+        partition.sort(key=lambda x: x["offset"])
+
+        # shorten regions so that they don't overlap
+        if len(partition) >= 2 and partition[0]["base"] != partition[1]["base"]:
+            partition[0]["length"] = partition[1]["base"] - \
+                partition[0]["base"]
+        if len(partition) >= 3 and partition[1]["base"] != partition[2]["base"]:
+            partition[1]["length"] = partition[2]["base"] - \
+                partition[1]["base"]
+
+    return regions
+
+
+def regions_overlap(region_a, region_b):
+    """Test if regions are identical"""
+    if region_a is None or region_b is None:
+        return False
+    return region_a["base"] == region_b["base"] and region_a["length"] == region_b["length"]
+
+
+def invert_regions_to_memories(regions):
+    """Given the requested regions with computed effective address ranges,
+       invert the data structure to get the list of memories for the
+       linker script"""
+    memories = dict()
+
+    if regions_overlap(regions["ram"], regions["entry"]):
+        memories["testram"] = {
+            "name": "testram",
+            "base": regions["ram"]["base"],
+            "length": regions["ram"]["length"],
+            "contents": ["ram", "entry"],
+            "path": regions["ram"]["node"].get_path()
+        }
+        if regions_overlap(regions["itim"], regions["entry"]):
+            memories["testram"]["contents"].append("itim")
+        elif regions["itim"] is not None:
+            memories["itim"] = {
+                "name": "itim",
+                "base": regions["itim"]["base"],
+                "length": regions["itim"]["length"],
+                "contents": ["itim"],
+                "path": regions["itim"]["node"].get_path()
+            }
+    else:
+        memories["rom"] = {
+            "name": "rom",
+            "base": regions["entry"]["base"],
+            "length": regions["entry"]["length"],
+            "contents": ["entry"],
+            "path": regions["entry"]["node"].get_path()
+        }
+        memories["ram"] = {
+            "name": "ram",
+            "base": regions["ram"]["base"],
+            "length": regions["ram"]["length"],
+            "contents": ["ram"],
+            "path": regions["ram"]["node"].get_path()
+        }
+        if regions_overlap(regions["entry"], regions["itim"]):
+            memories["rom"]["contents"].append("itim")
+        elif regions_overlap(regions["ram"], regions["itim"]):
+            memories["ram"]["contents"].append("itim")
+        elif regions["itim"] is None:
+            memories["ram"]["contents"].append("itim")
+        else:
+            memories["itim"] = {
+                "name": "itim",
+                "base": regions["itim"]["base"],
+                "length": regions["itim"]["length"],
+                "contents": ["itim"],
+                "path": regions["itim"]["node"].get_path()
+            }
+
+    return memories
+
+
+def attributes_from_contents(contents):
+    """Get the attributes from the contents of the memory"""
+    attributes = ""
+    if "entry" in contents:
+        attributes += "rxi"
+    if "ram" in contents:
+        attributes += "rwa"
+    if "itim" in contents:
+        attributes += "rwxai"
+
+    # Remove duplicates
+    attributes = ''.join(sorted(list(set(attributes))))
+
+    antiattributes = ""
+    for char in "rwxai":
+        if char not in attributes:
+            antiattributes += char
+
+    if antiattributes != "":
+        attributes += "!" + antiattributes
+
+    return attributes
+
+
+def compute_attributes(memories):
+    """Given the list of memories and their contents, compute the linker
+       script attributes"""
+    for _, memory in memories.items():
+        memory["attributes"] = attributes_from_contents(memory["contents"])
+
+
+def format_hex(memories):
+    """Provide hex-formatted base and length for parameterizing template"""
+    for _, memory in memories.items():
+        memory["base_hex"] = "0x%x" % memory["base"]
+        memory["length_hex"] = "0x%x" % memory["length"]

--- a/templates/base.lds
+++ b/templates/base.lds
@@ -19,7 +19,7 @@ ENTRY(_enter)
 MEMORY
 {
     {% for memory in memories -%}
-        {{ memory.name }} ({{ memory.attributes }}) : ORIGIN = {{ memory.base }}, LENGTH = {{ memory.size }}
+        {{ memory.name }} ({{ memory.attributes }}) : ORIGIN = {{ memory.base_hex }}, LENGTH = {{ memory.length_hex }}
     {% else %}
         {{ missingvalue("No memories are defined, cannot render linker script!") }}
     {%- endfor %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 SiFive Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/e31_no_chosen.dts
+++ b/tests/e31_no_chosen.dts
@@ -1,0 +1,116 @@
+/dts-v1/;
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "SiFive,FE300-dev", "fe300-dev", "sifive-dev";
+	model = "SiFive,FE300";
+	chosen {
+		metal,boothart = <&L7>;
+	};
+	L15: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		L7: cpu@0 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			hardware-exec-breakpoint-count = <4>;
+			i-cache-block-size = <64>;
+			i-cache-sets = <128>;
+			i-cache-size = <16384>;
+			reg = <0x0>;
+			riscv,isa = "rv32imac";
+			riscv,pmpregions = <8>;
+			sifive,dtim = <&L6>;
+			sifive,itim = <&L5>;
+			status = "okay";
+			timebase-frequency = <1000000>;
+			L4: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L14: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "SiFive,FE300-soc", "fe300-soc", "sifive-soc", "simple-bus";
+		ranges;
+		L12: ahb-periph-port@20000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "sifive,ahb-periph-port", "sifive,ahb-port", "sifive,periph-port", "simple-external-bus", "simple-bus";
+			ranges = <0x20000000 0x20000000 0x20000000>;
+			sifive,port-width-bytes = <4>;
+			testram0: testram@20000000 {
+				compatible = "sifive,testram0";
+				reg = <0x20000000 0x1fffffff>;
+				reg-names = "mem";
+			};
+		};
+		L11: ahb-sys-port@40000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "sifive,ahb-sys-port", "sifive,ahb-port", "sifive,sys-port", "simple-external-bus", "simple-bus";
+			ranges = <0x40000000 0x40000000 0x20000000>;
+			sifive,port-width-bytes = <4>;
+			testram1: testram@40000000 {
+				compatible = "sifive,testram0";
+				reg = <0x40000000 0x1fffffff>;
+				reg-names = "mem";
+			};
+		};
+		L2: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L4 3 &L4 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L3: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L4 65535>;
+			reg = <0x0 0x1000>;
+			reg-names = "control";
+		};
+		L6: dtim@80000000 {
+			compatible = "sifive,dtim0";
+			reg = <0x80000000 0x10000>;
+			reg-names = "mem";
+		};
+		L0: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+		};
+		L9: global-external-interrupts {
+			compatible = "sifive,global-external-interrupts0";
+			interrupt-parent = <&L1>;
+			interrupts = <1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127>;
+		};
+		L1: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L4 11>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <127>;
+		};
+		L5: itim@1800000 {
+			compatible = "sifive,itim0";
+			reg = <0x1800000 0x2000 0x1802000 0x2000>;
+			reg-names = "mem", "control";
+		};
+		L10: local-external-interrupts-0 {
+			compatible = "sifive,local-external-interrupts0";
+			interrupt-parent = <&L4>;
+			interrupts = <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31>;
+		};
+		L8: teststatus@4000 {
+			compatible = "sifive,test0";
+			reg = <0x4000 0x1000>;
+			reg-names = "control";
+		};
+	};
+};

--- a/tests/test-memory-map.py
+++ b/tests/test-memory-map.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 SiFive Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+import pydevicetree
+
+from memory_map import *
+
+
+def add_property(chosen, prop_s):
+    chosen.properties.append(pydevicetree.Property.from_dts(prop_s))
+
+
+class TestMemoryMap(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tree = pydevicetree.Devicetree.parseFile("tests/e31_no_chosen.dts")
+        cls.chosen = cls.tree.get_by_path("/chosen")
+
+        cls.testram_path = "/soc/ahb-periph-port@20000000/testram@20000000"
+        cls.testram_base = 0x20000000
+        cls.testram_length = 0x1fffffff
+
+        cls.dtim_path = "/soc/dtim@80000000"
+        cls.dtim_base = 0x80000000
+        cls.dtim_length = 0x10000
+
+        cls.itim_path = "/soc/itim@1800000"
+        cls.itim_base = 0x1800000
+        cls.itim_length = 0x2000
+
+    def tearDown(self):
+        # Clean up chosen properties between tests
+        delete_names = ["metal,entry", "metal,ram", "metal,itim"]
+        new_properties = [
+            p for p in self.chosen.properties if p.name not in delete_names]
+        self.chosen.properties = new_properties
+
+    def test_get_chosen_region(self):
+        add_property(self.chosen, "metal,entry = <&testram0 0 0>;")
+
+        result = get_chosen_region(self.tree, "metal,entry")
+
+        self.assertTrue(isinstance(result["node"], pydevicetree.Node))
+        self.assertEqual(result["node"].get_path(
+        ), "/soc/ahb-periph-port@20000000/testram@20000000")
+        self.assertEqual(result["region"], 0)
+        self.assertEqual(result["offset"], 0)
+
+    def test_get_chosen_regions(self):
+        add_property(self.chosen, "metal,entry = <&testram0 0 0>;")
+        add_property(self.chosen, "metal,ram = <&L6 0 0>;")
+        add_property(self.chosen, "metal,itim = <&L5 0 0>;")
+
+        regions = get_chosen_regions(self.tree)
+
+        self.assertTrue(isinstance(
+            regions["entry"]["node"], pydevicetree.Node))
+        self.assertEqual(
+            regions["entry"]["node"].get_path(), self.testram_path)
+        self.assertEqual(regions["entry"]["region"], 0)
+        self.assertEqual(regions["entry"]["offset"], 0)
+        self.assertTrue(isinstance(regions["ram"]["node"], pydevicetree.Node))
+        self.assertEqual(regions["ram"]["node"].get_path(), self.dtim_path)
+        self.assertEqual(regions["ram"]["region"], 0)
+        self.assertEqual(regions["ram"]["offset"], 0)
+        self.assertTrue(isinstance(regions["itim"]["node"], pydevicetree.Node))
+        self.assertEqual(regions["itim"]["node"].get_path(), self.itim_path)
+        self.assertEqual(regions["itim"]["region"], 0)
+        self.assertEqual(regions["itim"]["offset"], 0)
+
+    def test_compute_address_range(self):
+        region = {
+            "node": self.tree.get_by_path(self.testram_path),
+            "region": 0,
+            "offset": 0,
+        }
+        compute_address_range(region)
+
+        self.assertEqual(region["base"], self.testram_base)
+        self.assertEqual(region["length"], self.testram_length)
+
+    def test_compute_address_ranges(self):
+        regions = {
+            "entry": {
+                "node": self.tree.get_by_path(self.testram_path),
+                "region": 0,
+                "offset": 0,
+            },
+            "ram": {
+                "node": self.tree.get_by_path(self.dtim_path),
+                "region": 0,
+                "offset": 0,
+            },
+            "itim": None,
+        }
+        compute_address_ranges(regions)
+
+        self.assertEqual(regions["entry"]["base"], self.testram_base)
+        self.assertEqual(regions["entry"]["length"], self.testram_length)
+        self.assertEqual(regions["ram"]["base"], self.dtim_base)
+        self.assertEqual(regions["ram"]["length"], self.dtim_length)
+
+    def test_compute_address_ranges_with_overlap(self):
+        regions = {
+            "entry": {
+                "node": self.tree.get_by_path(self.testram_path),
+                "region": 0,
+                "offset": 0,
+            },
+            "ram": {
+                "node": self.tree.get_by_path(self.testram_path),
+                "region": 0,
+                "offset": 0x10000,
+            },
+            "itim": {
+                "node": self.tree.get_by_path(self.testram_path),
+                "region": 0,
+                "offset": 0x20000,
+            },
+        }
+        compute_address_ranges(regions)
+
+        self.assertEqual(regions["entry"]["base"], self.testram_base)
+        self.assertEqual(regions["entry"]["length"], 0x10000)
+        self.assertEqual(regions["ram"]["base"], self.testram_base + 0x10000)
+        self.assertEqual(regions["ram"]["length"], 0x10000)
+        self.assertEqual(regions["itim"]["base"], self.testram_base + 0x20000)
+        self.assertEqual(regions["itim"]["length"],
+                         self.testram_length - 0x20000)
+
+    def test_regions_overlap(self):
+        regions = {
+            "entry": {
+                "base": 0x20000000,
+                "length": 0x1fffffff,
+            },
+            "ram": {
+                "base": 0x20000000,
+                "length": 0x1fffffff,
+            },
+            "itim": {
+                "base": 0x1800000,
+                "length": 0x2000,
+            },
+        }
+
+        self.assertTrue(regions_overlap(regions["entry"], regions["ram"]))
+        self.assertFalse(regions_overlap(regions["entry"], regions["itim"]))
+        self.assertFalse(regions_overlap(regions["ram"], regions["itim"]))
+
+    def test_get_memories_ram_rom_itim(self):
+        add_property(self.chosen, "metal,entry = <&testram0 0 0>;")
+        add_property(self.chosen, "metal,ram = <&L6 0 0>;")
+        add_property(self.chosen, "metal,itim = <&L5 0 0>;")
+
+        memories = get_memories(self.tree)
+
+        self.assertTrue("entry" in memories["rom"]["contents"])
+        self.assertTrue("ram" in memories["ram"]["contents"])
+        self.assertTrue("itim" in memories["itim"]["contents"])
+
+    def test_get_memories_ram_rom_1(self):
+        add_property(self.chosen, "metal,entry = <&testram0 0 0>;")
+        add_property(self.chosen, "metal,ram = <&L6 0 0>;")
+        add_property(self.chosen, "metal,itim = <&L6 0 0>;")
+
+        memories = get_memories(self.tree)
+
+        self.assertTrue("entry" in memories["rom"]["contents"])
+        self.assertTrue("ram" in memories["ram"]["contents"])
+        self.assertTrue("itim" in memories["ram"]["contents"])
+
+    def test_get_memories_ram_rom_2(self):
+        add_property(self.chosen, "metal,entry = <&testram0 0 0>;")
+        add_property(self.chosen, "metal,ram = <&L6 0 0>;")
+        add_property(self.chosen, "metal,itim = <&testram0 0 0>;")
+
+        memories = get_memories(self.tree)
+
+        self.assertTrue("entry" in memories["rom"]["contents"])
+        self.assertTrue("ram" in memories["ram"]["contents"])
+        self.assertTrue("itim" in memories["rom"]["contents"])
+
+    def test_get_memories_testram_itim(self):
+        add_property(self.chosen, "metal,entry = <&testram0 0 0>;")
+        add_property(self.chosen, "metal,ram = <&testram0 0 0>;")
+        add_property(self.chosen, "metal,itim = <&L5 0 0>;")
+
+        memories = get_memories(self.tree)
+
+        self.assertTrue("entry" in memories["testram"]["contents"])
+        self.assertTrue("ram" in memories["testram"]["contents"])
+        self.assertTrue("itim" in memories["itim"]["contents"])
+
+    def test_get_memories_testram(self):
+        add_property(self.chosen, "metal,entry = <&testram0 0 0>;")
+        add_property(self.chosen, "metal,ram = <&testram0 0 0>;")
+        add_property(self.chosen, "metal,itim = <&testram0 0 0>;")
+
+        memories = get_memories(self.tree)
+
+        self.assertTrue("entry" in memories["testram"]["contents"])
+        self.assertTrue("ram" in memories["testram"]["contents"])
+        self.assertTrue("itim" in memories["testram"]["contents"])
+
+    def test_attributes_from_contents(self):
+        self.assertEqual(attributes_from_contents(["entry"]), "irx!wa")
+        self.assertEqual(attributes_from_contents(["ram"]), "arw!xi")
+        self.assertEqual(attributes_from_contents(["itim"]), "airwx")
+        self.assertEqual(attributes_from_contents(["entry", "ram"]), "airwx")
+        self.assertEqual(attributes_from_contents(["ram", "itim"]), "airwx")
+        self.assertEqual(attributes_from_contents(["entry", "itim"]), "airwx")
+        self.assertEqual(attributes_from_contents(
+            ["entry", "ram", "itim"]), "airwx")
+
+    def test_format_hex(self):
+        regions = {
+            "entry": {
+                "base": 0x20000000,
+                "length": 0x1fffffff,
+            },
+            "ram": {
+                "base": 0x80000000,
+                "length": 0x10000,
+            },
+            "itim": {
+                "base": 0x1800000,
+                "length": 0x2000,
+            },
+        }
+        format_hex(regions)
+
+        self.assertEqual(regions["entry"]["base_hex"], "0x20000000")
+        self.assertEqual(regions["entry"]["length_hex"], "0x1fffffff")
+        self.assertEqual(regions["ram"]["base_hex"], "0x80000000")
+        self.assertEqual(regions["ram"]["length_hex"], "0x10000")
+        self.assertEqual(regions["itim"]["base_hex"], "0x1800000")
+        self.assertEqual(regions["itim"]["length_hex"], "0x2000")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/theory_of_operation.md
+++ b/theory_of_operation.md
@@ -1,0 +1,601 @@
+# Mapping Devicetree to Linker Script Contents
+
+## Step 0: Devicetree
+
+### Required `/chosen` node properties:
+
+ - `metal,entry`
+ - `metal,ram`
+
+### Optional `/chosen` node properties:
+
+ - `metal,itim`
+
+## Step 1: Extract Devicetree Content
+
+The following are the valid possible results of parsing the Devicetree
+
+### All defined, none overlapping
+
+ - `metal,entry`
+ - `metal,ram`
+ - `metal,itim`
+ - All point at different memories in the design
+
+```
+{
+    "entry": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "ram": {
+        "node": <Node b>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "itim": {
+        "node": <Node c>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+}
+```
+
+### All defined, all overlapping
+
+ - `metal,entry`
+ - `metal,ram`
+ - `metal,itim`
+ - All point at the same memory in the design
+
+```
+{
+    "entry": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "ram": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "itim": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+}
+```
+
+### All defined, RAM and ITIM overlapping
+
+ - `metal,entry`
+ - `metal,ram`
+ - `metal,itim`
+ - RAM and ITIM point at the same memory in the design
+
+```
+{
+    "entry": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "ram": {
+        "node": <Node b>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "itim": {
+        "node": <Node b>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+}
+```
+
+### All defined, RAM and Entry overlapping
+
+ - `metal,entry`
+ - `metal,ram`
+ - `metal,itim`
+ - RAM and Entry point at the same memory in the design
+
+```
+{
+    "entry": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "ram": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "itim": {
+        "node": <Node b>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+}
+```
+
+### All defined, ITIM and Entry overlapping
+
+ - `metal,entry`
+ - `metal,ram`
+ - `metal,itim`
+ - RAM and Entry point at the same memory in the design
+
+```
+{
+    "entry": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "ram": {
+        "node": <Node b>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "itim": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+}
+```
+
+### RAM and Entry Defined, none overlapping
+
+ - `metal,entry`
+ - `metal,ram`
+ - Both point at different memories in the design
+
+```
+{
+    "entry": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "ram": {
+        "node": <Node b>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+}
+```
+
+### RAM and Entry Defined, both overlapping
+
+ - `metal,entry`
+ - `metal,ram`
+ - Both point at the same memory in the design
+
+```
+{
+    "entry": {
+        "node": <Node a>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+    "ram": {
+        "node": <Node b>, # type: pydevicetree.Node
+        "region": 0, # type: int
+        "offset", 0, # type: int
+    },
+}
+```
+
+### Different offsets in the same node
+
+The different regions (entry, ram, itim) may point at the same node but to different offsets.
+In this case, the regions should not be considered overlapping.
+
+### Invalid states
+
+ - `metal,entry` not provided
+ - `metal,ram` not provided
+ - Requested region or offset is not available in the device
+
+## Step 2 Convert from `(node, region, offset)` to address range
+
+### All defined, none overlapping
+
+```
+{
+    "entry": {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+    },
+    "ram": {
+        "base": 0x80000000, # type: int
+        "length": 0x10000, # type: int
+    },
+    "itim": {
+        "base": 0x8000000, # type: int
+        "length": 0x8000, # type: int
+    },
+}
+```
+
+### All defined, all overlapping
+
+```
+{
+    "entry": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+    "ram": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+    "itim": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+}
+```
+
+### All defined, RAM and ITIM overlapping
+
+```
+{
+    "entry": {
+        "base": 0x20000000, # type: int
+        "length": 0x10000, # type: int
+    },
+    "ram": {
+        "base": 0x80000000, # type: int
+        "length": 0x10000, # type: int
+    },
+    "itim": {
+        "base": 0x80000000, # type: int
+        "length": 0x10000, # type: int
+    },
+}
+```
+
+### All defined, RAM and Entry overlapping
+
+```
+{
+    "entry": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+    "ram": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+    "itim": {
+        "base": 0x8000000, # type: int
+        "length": 0x8000, # type: int
+    },
+}
+```
+
+### All defined, ITIM and Entry overlapping
+
+```
+{
+    "entry": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+    "ram": {
+        "base": 0x80000000, # type: int
+        "length": 0x1000000, # type: int
+    },
+    "itim": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+}
+```
+
+### RAM and Entry Defined, none overlapping
+
+```
+{
+    "entry": {
+        "base": 0x20000000, # type: int
+        "length": 0x10000, # type: int
+    },
+    "ram": {
+        "base": 0x80000000, # type: int
+        "length": 0x10000, # type: int
+    },
+}
+```
+
+### RAM and Entry Defined, both overlapping
+
+```
+{
+    "entry": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+    "ram": {
+        "base": 0x60000000, # type: int
+        "length": 0x100000, # type: int
+    },
+}
+```
+
+## Step 3: Invert Structure to get memories and their contents
+
+### RAM, ROM, ITIM
+
+```
+memories = {
+    "rom" {
+        "base": 0x20000000, # type: int
+        "length": 0x100000, # type: int
+        "contents": ["entry"] # type: List[str]
+    },
+    "ram" {
+        "base": 0x80000000, # type: int
+        "length": 0x1000000, # type: int
+        "contents": ["ram"] # type: List[str]
+    },
+    "itim" {
+        "base": 0x8000000 # type: int
+        "length": 0x1000 # type: int
+        "contents": ["itim"] # type: List[str]
+    },
+}
+```
+
+### RAM, ROM
+
+```
+memories = {
+    "rom" {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+        "contents": ["entry"] # type: List[str]
+    },
+    "ram" {
+        "base": 0x80000000, # type: int
+        "length": 0x1000000, # type: int
+        "contents": ["ram", "itim"] # type: List[str]
+    },
+}
+```
+
+or
+
+```
+memories = {
+    "rom" {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+        "contents": ["entry", "itim"] # type: List[str]
+    },
+    "ram" {
+        "base": 0x80000000, # type: int
+        "length": 0x1000000, # type: int
+        "contents": ["ram"] # type: List[str]
+    },
+}
+```
+
+### TESTRAM, ITIM
+
+```
+memories = {
+    "testram" {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+        "contents": ["entry", "ram"] # type: List[str]
+    },
+    "itim" {
+        "base": 0x8000000 # type: int
+        "length": 0x1000 # type: int
+        "contents": ["itim"] # type: List[str]
+    },
+}
+```
+
+### TESTRAM
+
+```
+memories = {
+    "testram" {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+        "contents": ["entry", "ram", "itim"] # type: List[str]
+    },
+}
+```
+
+## Step 4: Add attributes based on contents
+
+- "entry" gets "rxi"
+- "ram" gets "rwa"
+- "itim gets "rwxi"
+
+### RAM, ROM, ITIM
+
+```
+memories = {
+    "rom" {
+        "base": 0x20000000, # type: int
+        "length": 0x100000,0 # type: int
+        "attributes": "rxi!wa", # type: str
+        "contents": ["entry"] # type: List[str]
+    },
+    "ram" {
+        "base": 0x80000000, # type: int
+        "length": 0x1000000, # type: int
+        "attributes": "rwa!xi", # type: str
+        "contents": ["ram"] # type: List[str]
+    },
+    "itim" {
+        "base": 0x8000000 # type: int
+        "length": 0x1000 # type: int
+        "attributes": "rwxai", # type: str
+        "contents": ["itim"] # type: List[str]
+    },
+}
+```
+
+### RAM, ROM
+
+```
+memories = {
+    "rom" {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+        "attributes": "rxi!wa", # type: str
+        "contents": ["entry"] # type: List[str]
+    },
+    "ram" {
+        "base": 0x80000000, # type: int
+        "length": 0x1000000, # type: int
+        "attributes": "rwxa!i", # type: str
+        "contents": ["ram", "itim"] # type: List[str]
+    },
+}
+```
+
+or
+
+```
+memories = {
+    "rom" {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+        "attributes": "rxi!wa", # type: str
+        "contents": ["entry", "itim"] # type: List[str]
+    },
+    "ram" {
+        "base": 0x80000000, # type: int
+        "length": 0x1000000, # type: int
+        "attributes": "rwxa!i", # type: str
+        "contents": ["ram"] # type: List[str]
+    },
+}
+```
+
+### TESTRAM, ITIM
+
+```
+memories = {
+    "testram" {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+        "attributes": "rwxai", # type: str
+        "contents": ["entry", "ram"] # type: List[str]
+    },
+    "itim" {
+        "base": 0x8000000 # type: int
+        "length": 0x1000 # type: int
+        "attributes": "rwxai", # type: str
+        "contents": ["itim"] # type: List[str]
+    },
+}
+```
+
+### TESTRAM
+
+```
+memories = {
+    "testram" {
+        "base": 0x20000000, # type: int
+        "length": 0x1000000, # type: int
+        "attributes": "rwxai", # type: str
+        "contents": ["entry", "ram", "itim"] # type: List[str]
+    },
+}
+```
+
+## Step 5: Turn contents into lma/vma pairs
+
+### RAM, ROM, ITIM
+
+```
+rom = {
+    "lma": "rom",
+}
+ram = {
+    "lma": "rom",
+    "vma": "ram",
+}
+itim = {
+    "lma": "rom",
+    "vma": "itim",
+}
+```
+
+### RAM, ROM
+
+```
+rom = {
+    "lma": "rom",
+}
+ram = {
+    "lma": "rom",
+    "vma": "ram",
+}
+itim = {
+    "lma": "rom",
+    "vma": "ram",
+}
+```
+
+or
+
+```
+rom = {
+    "lma": "rom",
+}
+ram = {
+    "lma": "rom",
+    "vma": "ram",
+}
+itim = {
+    "lma": "rom",
+    "vma": "rom",
+}
+```
+
+### TESTRAM, ITIM
+
+```
+rom = {
+    "lma": "testram",
+}
+ram = {
+    "lma": "testram",
+    "vma": "testram",
+}
+itim = {
+    "lma": "testram",
+    "vma": "ram",
+}
+```
+
+### TESTRAM
+
+```
+rom = {
+    "lma": "testram",
+}
+ram = {
+    "lma": "testram",
+    "vma": "testram",
+}
+itim = {
+    "lma": "testram",
+    "vma": "testram",
+}
+```


### PR DESCRIPTION
Go back and redo the entire algorithm for turning the `chosen`
properties into the linker script parameterization using functional
decomposition.

I wrote down all of the steps in between a Devicetree and the resulting
data structures for the template rendering in theory_of_operation.md.
Then I created a separate module memory_map.py which functionally
decomposes that algorithm and implements it step-by-step.