### PR TITLE
Fix arrangement of readonly data placed in ram

### DIFF
--- a/templates/base.lds
+++ b/templates/base.lds
@@ -201,24 +201,23 @@ SECTIONS
     .data : ALIGN(8) {
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
-{% if ramrodata %}
-        /* Read-only data is placed in RAM to improve performance, since
-         * read-only memory generally has higher latency than RAM */
-        *(.rdata)
-        *(.rodata .rodata.*)
-        *(.gnu.linkonce.r.*)
-{% endif %}
         . = ALIGN(8);
         PROVIDE( __global_pointer$ = . + 0x800 );
         *(.sdata .sdata.* .sdata2.*)
         *(.gnu.linkonce.s.*)
-        . = ALIGN(8);
 {% if ramrodata %}
+        /* Read-only data is placed in RAM to improve performance, since
+         * read-only memory generally has higher latency than RAM */
+        . = ALIGN(8);
         *(.srodata.cst16)
         *(.srodata.cst8)
         *(.srodata.cst4)
         *(.srodata.cst2)
         *(.srodata .srodata.*)
+        . = ALIGN(8);
+        *(.rdata)
+        *(.rodata .rodata.*)
+        *(.gnu.linkonce.r.*)
 {% endif %}
     } >{{ ram.vma }} AT>{{ ram.lma }}
 


### PR DESCRIPTION
This caused a performance regression on some standard cores with Dhrystone. This makes the readonly data layout match what it was with the old ldscript generator and fixes the regression.