### PR TITLE
Create Wake API for ldscript-generator

### DIFF
--- a/.github/workflows/wake.yml
+++ b/.github/workflows/wake.yml
@@ -1,0 +1,39 @@
+name: wake-api-test
+
+on:
+  push:
+    path-ignore:
+      - '**.md'
+      - 'LICENSE'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      # $WIT_WORKSPACE path is relative to $GITHUB_WORKSPACE
+      WIT_WORKSPACE: wit-workspace
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: wit-packages/ldscript-generator
+
+      - name: 'Init Wit Workspace'
+        uses: sifive/wit/actions/wit@v0.12.0
+        with:
+          command: init
+          arguments: |
+            ${{ env.WIT_WORKSPACE }}
+            -a ./wit-packages/ldscript-generator
+            -a git@github.com:sifive/environment-blockci-sifive.git::0.3.0
+          force_github_https: true
+
+      - name: 'Run Wake API Test'
+        run: |
+          set -euo pipefail
+          docker run \
+            --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
+            --workdir="/mnt/workspace" \
+            --rm \
+            sifive/environment-blockci:0.3.0 \
+            ldscript-generator/tests/test-wake-api.sh

--- a/build.wake
+++ b/build.wake
@@ -2,14 +2,20 @@ tuple LdScriptGeneratorOptions =
   global TopDTSFile:    Path
   global OtherDTSFiles: List Path
   global OutputFile:    String
+  global Layout:        LdScriptLayout
+
+global data LdScriptLayout =
+  # The default mode tries to strike a good balance for all use-cases.
+  # If you don't need scratchpad or ramrodata modes, use the default one.
+  LDSCRIPT_DEFAULT
   # Scratchpad mode places the entire binary contents into the memory
   # selected by metal,ram in the chosen node.
-  global Scratchpad:    Boolean
+  LDSCRIPT_SCRATCHPAD
   # Ramrodata mode places all read-only data into writable memory under
   # the assumption that this decreases read latency for benchmarks.
   # Also, if the memory selected by metal,itim is large enough, this places
   # all non-init text into the ITIM.
-  global Ramrodata:     Boolean
+  LDSCRIPT_RAMRODATA
 
 # Instead of copying the script sources into build/{here}, we'll just
 # execute directly out of the package directory, since nothing gets
@@ -24,11 +30,13 @@ def generatorDir = here
 #   - topDTSFile: The top-level Devicetree source file
 #   - otherDTSFiles: any other Devicetree source files included in the
 #                    heirarchy of Devicetree source files
+#   - layout: one of {LDSCRIPT_DEFAULT, LDSCRIPT_SCRATCHPAD,
+#                     LDSCRIPT_RAMRODATA}
 #   - outputFile: A string representing the path of the output file to
 #                 produce
 #######################################################################
-global def makeLdScriptGeneratorOptions topDTSFile otherDTSFiles outputFile =
-  LdScriptGeneratorOptions topDTSFile otherDTSFiles outputFile False False
+global def makeLdScriptGeneratorOptions topDTSFile otherDTSFiles layout outputFile =
+  LdScriptGeneratorOptions topDTSFile otherDTSFiles outputFile layout
 
 global def runLdScriptGenerator options =
   def topDTSFile = options.getLdScriptGeneratorOptionsTopDTSFile
@@ -49,15 +57,10 @@ global def runLdScriptGenerator options =
       "-o", options.getLdScriptGeneratorOptionsOutputFile,
       Nil
 
-    def scratchpad = match options.getLdScriptGeneratorOptionsScratchpad
-      True  = "--scratchpad", Nil
-      False = Nil
-
-    def ramrodata = match options.getLdScriptGeneratorOptionsRamrodata
-      True  = "--ramrodata", Nil
-      False = Nil
-
-    base ++ scratchpad ++ ramrodata
+    match options.getLdScriptGeneratorOptionsLayout
+      LDSCRIPT_DEFAULT    = base
+      LDSCRIPT_SCRATCHPAD = "--scratchpad", base
+      LDSCRIPT_RAMRODATA  = "--ramrodata", base
 
   makePlan (pythonCommand "{generatorDir}/generate_ldscript.py" args) inputs
   | addPlanRelativePath "PYTHONPATH" generatorDir

--- a/build.wake
+++ b/build.wake
@@ -29,7 +29,7 @@ def generatorDir = here
 # makeLdScriptGeneratorOptions takes the following parameters:
 #   - topDTSFile: The top-level Devicetree source file
 #   - otherDTSFiles: any other Devicetree source files included in the
-#                    heirarchy of Devicetree source files
+#                    hierarchy of Devicetree source files
 #   - layout: one of {LDSCRIPT_DEFAULT, LDSCRIPT_SCRATCHPAD,
 #                     LDSCRIPT_RAMRODATA}
 #   - outputFile: A string representing the path of the output file to

--- a/build.wake
+++ b/build.wake
@@ -1,0 +1,70 @@
+tuple LdScriptGeneratorOptions =
+  global TopDTSFile:    Path
+  global OtherDTSFiles: List Path
+  global OutputFile:    String
+  # Scratchpad mode places the entire binary contents into the memory
+  # selected by metal,ram in the chosen node.
+  global Scratchpad:    Boolean
+  # Ramrodata mode places all read-only data into writable memory under
+  # the assumption that this decreases read latency for benchmarks.
+  # Also, if the memory selected by metal,itim is large enough, this places
+  # all non-init text into the ITIM.
+  global Ramrodata:     Boolean
+
+# Instead of copying the script sources into build/{here}, we'll just
+# execute directly out of the package directory, since nothing gets
+# modified during execution.
+#
+# The virtualenv does get placed in build/{here} by
+# addPythonRequirementsEnv, along with a copy of requirements.txt
+def generatorDir = here
+
+#######################################################################
+# makeLdScriptGeneratorOptions takes the following parameters:
+#   - topDTSFile: The top-level Devicetree source file
+#   - otherDTSFiles: any other Devicetree source files included in the
+#                    heirarchy of Devicetree source files
+#   - outputFile: A string representing the path of the output file to
+#                 produce
+#######################################################################
+global def makeLdScriptGeneratorOptions topDTSFile otherDTSFiles outputFile =
+  LdScriptGeneratorOptions topDTSFile otherDTSFiles outputFile False False
+
+global def runLdScriptGenerator options =
+  def topDTSFile = options.getLdScriptGeneratorOptionsTopDTSFile
+  def otherDTSFiles = options.getLdScriptGeneratorOptionsOtherDTSFiles
+
+  def inputs =
+    # During execution, the generator needs access to both
+    # Python sources and the linker script template files
+    def generatorSources = sources here `.*\.(py|lds)`
+    def dtsSources = topDTSFile, otherDTSFiles
+    generatorSources ++ dtsSources
+
+  def outputs = options.getLdScriptGeneratorOptionsOutputFile, Nil
+
+  def args =
+    def base =
+      "-d", topDTSFile.getPathName,
+      "-o", options.getLdScriptGeneratorOptionsOutputFile,
+      Nil
+
+    def scratchpad = match options.getLdScriptGeneratorOptionsScratchpad
+      True  = "--scratchpad", Nil
+      False = Nil
+
+    def ramrodata = match options.getLdScriptGeneratorOptionsRamrodata
+      True  = "--ramrodata", Nil
+      False = Nil
+
+    base ++ scratchpad ++ ramrodata
+
+  makePlan (pythonCommand "{generatorDir}/generate_ldscript.py" args) inputs
+  | addPlanRelativePath "PYTHONPATH" generatorDir
+  | addPythonRequirementsEnv generatorDir
+  | setPlanFnOutputs (\_ outputs)
+  | runJob
+
+# This allows the python virtualenv to be created prior to running a build
+# with `wake preinstall Unit`.
+publish preinstall = (pythonRequirementsInstaller generatorDir), Nil

--- a/tests/spike/core.dts
+++ b/tests/spike/core.dts
@@ -1,0 +1,45 @@
+/dts-v1/;
+
+/ {
+  #address-cells = <2>;
+  #size-cells = <2>;
+  compatible = "ucbbar,spike-bare-dev";
+  model = "ucbbar,spike-bare";
+  cpus {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    timebase-frequency = <10000000>;
+    CPU0: cpu@0 {
+      device_type = "cpu";
+      reg = <0>;
+      status = "okay";
+      compatible = "riscv";
+      riscv,isa = "rv64imafdc";
+      mmu-type = "riscv,sv48";
+      clock-frequency = <1000000000>;
+      CPU0_intc: interrupt-controller {
+        #interrupt-cells = <1>;
+        interrupt-controller;
+        compatible = "riscv,cpu-intc";
+      };
+    };
+  };
+  memory@80000000 {
+    device_type = "memory";
+    reg = <0x0 0x80000000 0x0 0x80000000>;
+  };
+  soc {
+    #address-cells = <2>;
+    #size-cells = <2>;
+    compatible = "ucbbar,spike-bare-soc", "simple-bus";
+    ranges;
+    clint@2000000 {
+      compatible = "riscv,clint0";
+      interrupts-extended = <&CPU0_intc 3 &CPU0_intc 7 >;
+      reg = <0x0 0x2000000 0x0 0xc0000>;
+    };
+  };
+  htif {
+    compatible = "ucb,htif0";
+  };
+};

--- a/tests/spike/design.dts
+++ b/tests/spike/design.dts
@@ -1,0 +1,10 @@
+/include/ "core.dts"
+/ {
+	chosen {
+		metal,entry = <&{/memory@80000000} 0 0>;
+		metal,boothart = <&CPU0>;
+		stdout-path = "/htif:115200";
+		metal,itim = <&{/memory@80000000} 0 0>;
+		metal,ram = <&{/memory@80000000} 0 0>;
+	};
+};

--- a/tests/test-wake-api.sh
+++ b/tests/test-wake-api.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname $0)
+SPIKE_DTS_DIR=${SCRIPT_DIR}/spike
+
+OUTPUT_PATH="build/ldscript-generator"
+DEFAULT_OUTPUT="${OUTPUT_PATH}/metal.default.lds"
+RAMRODATA_OUTPUT="${OUTPUT_PATH}/metal.ramrodata.lds"
+SCRATCHPAD_OUTPUT="${OUTPUT_PATH}/metal.scratchpad.lds"
+
+wake --init .
+
+wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) \"${DEFAULT_OUTPUT}\")"
+wake -v "runLdScriptGenerator ((makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) \"${RAMRODATA_OUTPUT}\") | setLdScriptGeneratorOptionsRamrodata True)"
+wake -v "runLdScriptGenerator ((makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) \"${SCRATCHPAD_OUTPUT}\") | setLdScriptGeneratorOptionsScratchpad True)"
+
+OUTPUTS=($DEFAULT_OUTPUT $RAMRODATA_OUTPUT $SCRATCHPAD_OUTPUT )
+for file in ${OUTPUTS[@]}; do
+        >&2 echo "$0: Checking for ${file}"
+        if [ ! -f ${file} ] ; then
+                >&2 echo "$0: ERROR Failed to produce ${file}"
+                exit 1
+        fi
+
+        >&2 echo "$0: Checking for non-empty ${file}"
+        if [ `grep -c 'OUTPUT_ARCH' ${file}` -ne 1 ] ; then
+                >&2 echo "$0: ERROR ${file} has bad contents"
+                exit 2
+        fi
+done

--- a/tests/test-wake-api.sh
+++ b/tests/test-wake-api.sh
@@ -12,9 +12,9 @@ SCRATCHPAD_OUTPUT="${OUTPUT_PATH}/metal.scratchpad.lds"
 
 wake --init .
 
-wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) \"${DEFAULT_OUTPUT}\")"
-wake -v "runLdScriptGenerator ((makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) \"${RAMRODATA_OUTPUT}\") | setLdScriptGeneratorOptionsRamrodata True)"
-wake -v "runLdScriptGenerator ((makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) \"${SCRATCHPAD_OUTPUT}\") | setLdScriptGeneratorOptionsScratchpad True)"
+wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_DEFAULT \"${DEFAULT_OUTPUT}\")"
+wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_RAMRODATA \"${RAMRODATA_OUTPUT}\")"
+wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_SCRATCHPAD \"${SCRATCHPAD_OUTPUT}\")"
 
 OUTPUTS=($DEFAULT_OUTPUT $RAMRODATA_OUTPUT $SCRATCHPAD_OUTPUT )
 for file in ${OUTPUTS[@]}; do

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,0 +1,7 @@
+[
+    {
+        "commit": "a2e36e2c523c66d499810bd52a2956623e2066f6",
+        "name": "api-languages-sifive",
+        "source": "git@github.com:sifive/api-languages-sifive.git"
+    }
+]


### PR DESCRIPTION
Marking as draft until [my changes to api-languages-sifive](https://github.com/sifive/api-languages-sifive/pull/9) are merged.

Adds a Wake API to ldscript-generator and tests the API in CI so that it doesn't regress.

If this meets everyone's standards, I'll replicate the effort across the other new Python tooling replacements for freedom-devicetree-tools.

Before we merge, I'd like to know if we want to modify makeLdScriptGeneratorOptions to make it easier to request a scratchpad/ramrodata linker script. Maybe we should add an Enum to the API?