### PR TITLE
Avoid possible stack overflow.

### DIFF
--- a/templates/base.lds
+++ b/templates/base.lds
@@ -35,7 +35,7 @@ SECTIONS
      *
      *     -Xlinker --defsym=__stack_size=0xf00
      *
-     * where 0xf00 can be replaced with the value of your choice.
+     * where 0xf00 can be replaced with a multiple of 16 of your choice.
      *
      * __stack_size is PROVIDE-ed as a symbol so that initialization code
      * initializes the stack pointers for each hart at the right offset from
@@ -237,7 +237,7 @@ SECTIONS
     PROVIDE( metal_segment_bss_target_start = ADDR(.bss) );
     PROVIDE( metal_segment_bss_target_end = ADDR(.bss) + SIZEOF(.bss) );
 
-    .stack : {
+    .stack : ALIGN(16) {
         PROVIDE(metal_segment_stack_begin = .);
         . += __stack_size; /* Hart 0 */
         PROVIDE( _sp = . );


### PR DESCRIPTION
This PR resolves sifive/ldscript-generator#9 in a simple way: it aligns the `.stack` output section to a 16-byte boundary and requires the user to ensure that `__stack_size` is a multiple of 16. 

This fix is suboptimal, since
* it wastes up to 15*(`num_harts` + 1) bytes; and
* it overaligns in the (presumably) memory-penurious ILP32E case, where `sp` need only be 4-byte aligned. 

However, addressing either of these deficiencies would require changes to `freedom-metal`, whereas this fix is localized to `ldscript-generator`. Moreover, there's other "fat" (unnecessary padding and overalignment) in these linker scripts that could also be trimmed.

As a CX improvement, when the user provides a custom non-multiple-of-16 `__stack_size`, the linker script could emit a warning or round it (upwards) appropriately.  