### PR TITLE
Use all available RAM

### DIFF
--- a/templates/base.lds
+++ b/templates/base.lds
@@ -274,7 +274,7 @@ SECTIONS
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
-        . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
+        . = DEFINED(__heap_max) ? LENGTH(ram) - ( . - ORIGIN(ram)) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
     } >{{ ram.vma }}


### PR DESCRIPTION
Recall we have a `__heap_max` toggle: 
``` 
     * Altertatively, the heap can be grown to fill the entire remaining region
     * of RAM by adding the following to CFLAGS:
     *
     *     -Xlinker --defsym=__heap_max=1
     *
     * Note that depending on the memory layout, the bitness (32/64bit) of the
     * target, and the code model in use, this might cause a relocation error.
```
[...]
```
        /* If __heap_max is defined, grow the heap to use the rest of RAM,
         * otherwise set the heap size to __heap_size */
        . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
```
But this limits the heap to 4GB, even if more RAM is available! 

Presumably this restriction was instituted with a 32-bit address space in mind. But the "note", above, suggests otherwise. In any event, the user has been warned about the risks of `__heap_max`, so it seems to me that this restriction can be safely relaxed.

This PR relaxes the 4GB restriction, so `__heap_max` actually uses all the "remaining" RAM.