### PR TITLE
Remove redundant PROVIDE

### DIFF
--- a/templates/base.lds
+++ b/templates/base.lds
@@ -42,7 +42,6 @@ SECTIONS
      * the _sp symbol.
      */
     __stack_size = DEFINED(__stack_size) ? __stack_size : {{ default_stack_size|default("0x400") }};
-    PROVIDE(__stack_size = __stack_size);
 
     /* The size of the heap can be overriden at build-time by adding the
      * following to CFLAGS:


### PR DESCRIPTION
I think this PROVIDE statement is superfluous and can be removed.