### PR TITLE
Discard .eh_frame sections

### DIFF
--- a/templates/base.lds
+++ b/templates/base.lds
@@ -326,4 +326,13 @@ SECTIONS
         PROVIDE( _heap_end = . );
         PROVIDE( __heap_end = . );
     } >{{ ram.vma }} :ram
+
+    /* C++ exception handling information is
+     * not useful with our current runtime environment,
+     * and it consumes flash space. Discard it until
+     * we have something that can use it
+     */
+    /DISCARD/ : {
+	*(.eh_frame .eh_frame.*)
+    }
 }


### PR DESCRIPTION
These contain C++ exception handling information which isn't useful
for applications not using C++ exception handling. Let's discard them
for C applications.

Signed-off-by: Keith Packard <keithp@keithp.com>