### PR TITLE
Upgrade CI to test wake 0.18.

### DIFF
--- a/.github/workflows/wake.yml
+++ b/.github/workflows/wake.yml
@@ -19,13 +19,13 @@ jobs:
           path: wit-packages/ldscript-generator
 
       - name: 'Init Wit Workspace'
-        uses: sifive/wit/actions/wit@v0.12.0
+        uses: sifive/wit/actions/wit@v0.13.1
         with:
           command: init
           arguments: |
             ${{ env.WIT_WORKSPACE }}
             -a ./wit-packages/ldscript-generator
-            -a git@github.com:sifive/environment-blockci-sifive.git::0.3.0
+            -a git@github.com:sifive/environment-blockci-sifive.git::0.6.0
           force_github_https: true
 
       - name: 'Run Wake API Test'
@@ -35,7 +35,7 @@ jobs:
             --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
             --workdir="/mnt/workspace" \
             --rm \
-            sifive/environment-blockci:0.3.0 \
+            sifive/environment-blockci:0.6.0 \
             ldscript-generator/tests/test-wake-api.sh
 
       - name: 'Run generator install test'
@@ -45,5 +45,5 @@ jobs:
             --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
             --workdir="/mnt/workspace" \
             --rm \
-            sifive/environment-blockci:0.3.0 \
+            sifive/environment-blockci:0.6.0 \
             ldscript-generator/tests/test-wake-install.sh

--- a/build.wake
+++ b/build.wake
@@ -48,11 +48,12 @@ global def runLdScriptGenerator options =
   def inputs =
     # During execution, the generator needs access to both
     # Python sources and the linker script template files
+    def outputDir = mkdir (simplify "{output}/..")
     def generatorSources = sources here `.*\.(py|lds)`
     def dtsSources = topDTSFile, otherDTSFiles
-    generatorSources ++ dtsSources
+    outputDir, generatorSources ++ dtsSources
 
-  def outputs = options.getLdScriptGeneratorOptionsOutputFile, Nil
+  def output = options.getLdScriptGeneratorOptionsOutputFile
 
   def args =
     def base =
@@ -69,7 +70,7 @@ global def runLdScriptGenerator options =
   makePlan (pythonCommand "{generatorDir}/generate_ldscript.py" args) inputs
   | addPlanRelativePath "PYTHONPATH" generatorDir
   | addPythonRequirementsEnv generatorDir
-  | setPlanFnOutputs (\_ outputs)
+  | setPlanFnOutputs (\_ output, Nil)
   | runJob
 
 # This allows the python virtualenv to be created prior to running a build

--- a/tests/test-wake-api.sh
+++ b/tests/test-wake-api.sh
@@ -13,10 +13,10 @@ FREERTOS_OUTPUT="${OUTPUT_PATH}/metal.freertos.lds"
 
 wake --init .
 
-wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_DEFAULT \"${DEFAULT_OUTPUT}\")"
-wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_RAMRODATA \"${RAMRODATA_OUTPUT}\")"
-wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_SCRATCHPAD \"${SCRATCHPAD_OUTPUT}\")"
-wake -v "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_FREERTOS \"${FREERTOS_OUTPUT}\")"
+wake -v -x "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_DEFAULT \"${DEFAULT_OUTPUT}\")"
+wake -v -x "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_RAMRODATA \"${RAMRODATA_OUTPUT}\")"
+wake -v -x "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_SCRATCHPAD \"${SCRATCHPAD_OUTPUT}\")"
+wake -v -x "runLdScriptGenerator (makeLdScriptGeneratorOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) LDSCRIPT_FREERTOS \"${FREERTOS_OUTPUT}\")"
 
 OUTPUTS=($DEFAULT_OUTPUT $RAMRODATA_OUTPUT $SCRATCHPAD_OUTPUT )
 for file in ${OUTPUTS[@]}; do

--- a/tests/test-wake-install.sh
+++ b/tests/test-wake-install.sh
@@ -6,7 +6,7 @@ INSTALL_PATH="install-path"
 
 wake --init .
 
-wake -v "installLdScriptGenerator \"${INSTALL_PATH}\""
+wake -v -x "installLdScriptGenerator \"${INSTALL_PATH}\""
 
 >&2 echo "$0: Checking for ${INSTALL_PATH}"
 if [ ! -d ${INSTALL_PATH} ] ; then

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,7 @@
 [
     {
-        "commit": "a2e36e2c523c66d499810bd52a2956623e2066f6",
+        "//": "v0.2.2",
+        "commit": "29770efe2cf4e72edfb05da1baa1a08c5638f839",
         "name": "api-languages-sifive",
         "source": "git@github.com:sifive/api-languages-sifive.git"
     }


### PR DESCRIPTION
cc @mmjconolly, @terpstra, @jackkoenig 

We're doing a push to upgrade everything to wake 0.18. In this particular repo, there were no changes that needed to be made to the actual Wake code, but the CLI has slightly changed in that the `-x` is now required for the legacy behavior of passing in a string containing a Wake program.

This also required a bump to the wit dependency api-languages-sifive to a version that is known to work with wake 0.18 (which only required a minor syntax update).

This PR bumps the version of environment-blockci-sifive in CI to [v0.6.0](https://github.com/sifive/environment-blockci-sifive/releases/tag/0.6.0), which has wake 0.18.1 installed.

Note: This is failing for some reason, but I haven't root caused it yet. The error message is:

```sh
python3.7 -B ldscript-generator/generate_ldscript.py -d ldscript-generator/tests/spike/design.dts -o build/ldscript-generator/metal.default.lds # launched by: /usr/lib/wake/preload-wake .build/8.3845.in.json .build/8.3845.out.json
usage: generate_ldscript.py [-h] -d DTS [-o OUTPUT]
                            [--scratchpad | --ramrodata | --freertos]
generate_ldscript.py: error: argument -o/--output: can't open 'build/ldscript-generator/metal.default.lds': [Errno 2] No such file or directory: 'build/ldscript-generator/metal.default.lds'
'<hash>' build/ldscript-generator/metal.default.lds
hash_open: build/ldscript-generator/metal.default.lds: No such file or directory
```

I'm guessing it's probably related to either environment-blockci stuff or the wake version bump.