### PR TITLE
Unconditionally define __metal_eccscrub_bit

### DIFF
--- a/templates/base.lds
+++ b/templates/base.lds
@@ -98,7 +98,7 @@ SECTIONS
     PROVIDE( metal_{{ memory.name }}_memory_end = {{ memory.base_hex }} + {{ memory.length_hex }} );
 {% endfor %}
 {% else %}
-    PROVIDE(__metal_eccscrub_bit = {{ default(0) }});
+    PROVIDE(__metal_eccscrub_bit = 0);
 {% endif %}
 
     /* ROM SECTION

--- a/templates/base.lds
+++ b/templates/base.lds
@@ -97,6 +97,8 @@ SECTIONS
     PROVIDE( metal_{{ memory.name }}_memory_start = {{ memory.base_hex }} );
     PROVIDE( metal_{{ memory.name }}_memory_end = {{ memory.base_hex }} + {{ memory.length_hex }} );
 {% endfor %}
+{% else %}
+    PROVIDE(__metal_eccscrub_bit = {{ default(0) }});
 {% endif %}
 
     /* ROM SECTION


### PR DESCRIPTION
Otherwise you'd get an undefined symbol in `freedom-metal/scrub.S`.

A bigger question concerns the design decision to not make this symbol (and others) weak. I'll raise that in a different forum.

Background reading: https://github.com/sifive/freedom-metal/pull/319.