### PR TITLE
Fix FreeRTOS section organization

### DIFF
--- a/templates/base.lds
+++ b/templates/base.lds
@@ -153,6 +153,7 @@ SECTIONS
 
     .ctors : {
         {% if privilege_en %}
+        . = ALIGN(32);
         __unprivileged_section_start__ = .;
         {% endif %}
         KEEP (*crtbegin.o(.ctors))
@@ -186,10 +187,6 @@ SECTIONS
         *(.srodata.cst4)
         *(.srodata.cst2)
         *(.srodata .srodata.*)
-        {% if privilege_en %}
-        __unprivileged_section_end__ = .;
-        {% endif %}
-
     } >{{ rom.vma }} :rom
 {% endif %}
 
@@ -224,7 +221,9 @@ SECTIONS
         *(.text.startup .text.startup.*)
         *(.text .text.*)
         *(.gnu.linkonce.t.*)
-        {% if ramrodata and privilege_en %}
+        {% if privilege_en %}
+        *(freertos_system_calls)
+        . = ALIGN(32);
         __unprivileged_section_end__ = .;
         {% endif %}
     } >{{ rom.vma }} :text
@@ -244,6 +243,7 @@ SECTIONS
 
     .data : ALIGN(8) {
         {% if privilege_en %}
+        . = ALIGN(32);
         __unprivileged_data_section_start__ = .;
         {% endif %}
         *(.data .data.*)
@@ -299,6 +299,7 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(COMMON)
 {% if privilege_en %}
+        . = ALIGN(32);
         __unprivileged_data_section_end__ = .;
 {% endif %}
     } >{{ ram.vma }} :ram

--- a/templates/freertos.lds
+++ b/templates/freertos.lds
@@ -18,21 +18,21 @@
 {% set eccscrub_en = True %}
 
 {% block privileged_function_section %}
-	.privileged_functions : ALIGN (4) {
+	.privileged_functions : ALIGN (32) {
         __privileged_functions_start__ = .;
         KEEP(*(privileged_functions))
-        . = ALIGN(4);
+        . = ALIGN(32);
 		__privileged_functions_end__ = .;
 	} >{{ rom.vma }}
 {% endblock %} 
 
 {% block privileged_data_section %}
-    .privileged_data (NOLOAD) : ALIGN(8) {
+    .privileged_data (NOLOAD) : ALIGN(32) {
         __privileged_data_start__ = .;
 		*(privileged_data)
 		/* Non kernel data is kept out of the first _Privileged_Data_Region_Size
 		bytes of SRAM. */
-        . = ALIGN(4);
+        . = ALIGN(32);
 		__privileged_data_end__ = .;
 	} >{{ ram.vma }}
 {% endblock %} 


### PR DESCRIPTION
Example-freertos-pmp-bliky fail due to a section issue (pmp block the access to some function in user mode)
we change the token in order to fix it and align the beginning (and end) of section to avoid granularity issues.