### PR TITLE
Fix __heap_max feature on VCU118

### DIFF
--- a/templates/base.lds
+++ b/templates/base.lds
@@ -351,7 +351,7 @@ SECTIONS
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
-        . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
+        . = DEFINED(__heap_max) ? MIN( LENGTH({{ ram.vma }}) - ( . - ORIGIN({{ ram.vma }})) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
         PROVIDE( __heap_end = . );


### PR DESCRIPTION
On VCU118, the ram section is not named 'ram' but 'testram'.
Replaced hardcoded value in the template by '{{ram.vma}}' to get the correct name.