### PR TITLE
Fix LIM region extraction when either CCache 0 or 1 is present

### DIFF
--- a/memory_map.py
+++ b/memory_map.py
@@ -151,7 +151,7 @@ def get_chosen_region(dts, chosen_property_name):
 
 def get_lim_region(dts):
     """Extract LIM region"""
-    lim = dts.match("sifive,ccache0")
+    lim = dts.match("sifive,ccache[01]")
 
     if lim and len(lim[0].get_reg()) == 2:
         return {


### PR DESCRIPTION
Consider CCache 1 when extracting LIM regions. This is necessary to update BSPs since CCache1 is now introduced.

Related PR https://github.com/sifive/freedom-e-sdk-private/pull/218